### PR TITLE
Fixed the trending endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 .vscode/*
 includes/sun-backend-config.php
+request_tests.http


### PR DESCRIPTION
- Rewrote the way in which we get the top n tags from the bucket list
_get_top_n_tags now quicksorts the array of tags and then we take the top n elements from the sorted tags to get the trending tags
- All tags are also now lower cased (should I revert this?)
- optimized _post_to_tags so that it now only maps once to get the array of tags